### PR TITLE
Add base schema, models and seeders

### DIFF
--- a/kelasi/app/Models/AcademicYear.php
+++ b/kelasi/app/Models/AcademicYear.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AcademicYear extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'start_date',
+        'end_date',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'is_active' => 'boolean',
+    ];
+
+    public function classes()
+    {
+        return $this->hasMany(SchoolClass::class);
+    }
+
+    public function grades()
+    {
+        return $this->hasMany(Grade::class);
+    }
+}

--- a/kelasi/app/Models/Fee.php
+++ b/kelasi/app/Models/Fee.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Fee extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'school_id',
+        'name',
+        'amount',
+    ];
+
+    public function school()
+    {
+        return $this->belongsTo(School::class);
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+}

--- a/kelasi/app/Models/Grade.php
+++ b/kelasi/app/Models/Grade.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Grade extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'student_id',
+        'subject_id',
+        'teacher_id',
+        'academic_year_id',
+        'value',
+    ];
+
+    public function student()
+    {
+        return $this->belongsTo(Student::class);
+    }
+
+    public function subject()
+    {
+        return $this->belongsTo(Subject::class);
+    }
+
+    public function teacher()
+    {
+        return $this->belongsTo(Teacher::class);
+    }
+
+    public function academicYear()
+    {
+        return $this->belongsTo(AcademicYear::class);
+    }
+}

--- a/kelasi/app/Models/ParentModel.php
+++ b/kelasi/app/Models/ParentModel.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ParentModel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'parents';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'address',
+    ];
+
+    public function students()
+    {
+        return $this->hasMany(Student::class, 'parent_id');
+    }
+}

--- a/kelasi/app/Models/Payment.php
+++ b/kelasi/app/Models/Payment.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'student_id',
+        'fee_id',
+        'amount',
+        'payment_date',
+    ];
+
+    protected $casts = [
+        'payment_date' => 'date',
+    ];
+
+    public function student()
+    {
+        return $this->belongsTo(Student::class);
+    }
+
+    public function fee()
+    {
+        return $this->belongsTo(Fee::class);
+    }
+}

--- a/kelasi/app/Models/Role.php
+++ b/kelasi/app/Models/Role.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'guard_name',
+    ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'role_user');
+    }
+}

--- a/kelasi/app/Models/School.php
+++ b/kelasi/app/Models/School.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class School extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'address',
+        'phone',
+        'email',
+    ];
+
+    public function classes()
+    {
+        return $this->hasMany(SchoolClass::class);
+    }
+
+    public function students()
+    {
+        return $this->hasMany(Student::class);
+    }
+
+    public function teachers()
+    {
+        return $this->hasMany(Teacher::class);
+    }
+
+    public function fees()
+    {
+        return $this->hasMany(Fee::class);
+    }
+}

--- a/kelasi/app/Models/SchoolClass.php
+++ b/kelasi/app/Models/SchoolClass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SchoolClass extends Model
+{
+    use HasFactory;
+
+    protected $table = 'classes';
+
+    protected $fillable = [
+        'school_id',
+        'academic_year_id',
+        'name',
+        'level',
+    ];
+
+    public function school()
+    {
+        return $this->belongsTo(School::class);
+    }
+
+    public function academicYear()
+    {
+        return $this->belongsTo(AcademicYear::class);
+    }
+
+    public function students()
+    {
+        return $this->hasMany(Student::class, 'class_id');
+    }
+}

--- a/kelasi/app/Models/Student.php
+++ b/kelasi/app/Models/Student.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Student extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'school_id',
+        'class_id',
+        'parent_id',
+        'first_name',
+        'last_name',
+        'birth_date',
+        'gender',
+    ];
+
+    protected $casts = [
+        'birth_date' => 'date',
+    ];
+
+    public function school()
+    {
+        return $this->belongsTo(School::class);
+    }
+
+    public function class()
+    {
+        return $this->belongsTo(SchoolClass::class, 'class_id');
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(ParentModel::class, 'parent_id');
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+
+    public function grades()
+    {
+        return $this->hasMany(Grade::class);
+    }
+}

--- a/kelasi/app/Models/Subject.php
+++ b/kelasi/app/Models/Subject.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Subject extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'code',
+    ];
+
+    public function grades()
+    {
+        return $this->hasMany(Grade::class);
+    }
+}

--- a/kelasi/app/Models/Teacher.php
+++ b/kelasi/app/Models/Teacher.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Teacher extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'school_id',
+        'first_name',
+        'last_name',
+        'email',
+        'phone',
+        'hire_date',
+    ];
+
+    protected $casts = [
+        'hire_date' => 'date',
+    ];
+
+    public function school()
+    {
+        return $this->belongsTo(School::class);
+    }
+
+    public function grades()
+    {
+        return $this->hasMany(Grade::class);
+    }
+}

--- a/kelasi/app/Models/User.php
+++ b/kelasi/app/Models/User.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use App\Models\Role;
 
 class User extends Authenticatable
 {
@@ -57,5 +59,13 @@ class User extends Authenticatable
             ->take(2)
             ->map(fn ($word) => Str::substr($word, 0, 1))
             ->implode('');
+    }
+
+    /**
+     * Roles assigned to the user.
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class, 'role_user');
     }
 }

--- a/kelasi/database/migrations/2024_05_20_000001_create_schools_table.php
+++ b/kelasi/database/migrations/2024_05_20_000001_create_schools_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('schools', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('address')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('email')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('schools');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000002_create_academic_years_table.php
+++ b/kelasi/database/migrations/2024_05_20_000002_create_academic_years_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('academic_years', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->boolean('is_active')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('academic_years');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000003_create_classes_table.php
+++ b/kelasi/database/migrations/2024_05_20_000003_create_classes_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('classes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('academic_year_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('level')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('classes');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000004_create_parents_table.php
+++ b/kelasi/database/migrations/2024_05_20_000004_create_parents_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('parents', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('parents');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000005_create_students_table.php
+++ b/kelasi/database/migrations/2024_05_20_000005_create_students_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('students', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('class_id')->constrained('classes')->cascadeOnDelete();
+            $table->foreignId('parent_id')->nullable()->constrained('parents')->nullOnDelete();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->date('birth_date')->nullable();
+            $table->string('gender')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('students');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000006_create_teachers_table.php
+++ b/kelasi/database/migrations/2024_05_20_000006_create_teachers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teachers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_id')->constrained()->cascadeOnDelete();
+            $table->string('first_name');
+            $table->string('last_name');
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->date('hire_date')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teachers');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000007_create_subjects_table.php
+++ b/kelasi/database/migrations/2024_05_20_000007_create_subjects_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subjects', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subjects');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000008_create_fees_table.php
+++ b/kelasi/database/migrations/2024_05_20_000008_create_fees_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('fees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('school_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->decimal('amount', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fees');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000009_create_payments_table.php
+++ b/kelasi/database/migrations/2024_05_20_000009_create_payments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('student_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('fee_id')->constrained('fees')->cascadeOnDelete();
+            $table->decimal('amount', 10, 2);
+            $table->date('payment_date');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000010_create_grades_table.php
+++ b/kelasi/database/migrations/2024_05_20_000010_create_grades_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('grades', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('student_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('subject_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('teacher_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('academic_year_id')->constrained()->cascadeOnDelete();
+            $table->decimal('value', 5, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('grades');
+    }
+};

--- a/kelasi/database/migrations/2024_05_20_000011_create_roles_table.php
+++ b/kelasi/database/migrations/2024_05_20_000011_create_roles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('guard_name')->default('web');
+            $table->timestamps();
+        });
+
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->primary(['role_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('role_user');
+        Schema::dropIfExists('roles');
+    }
+};

--- a/kelasi/database/seeders/AcademicYearSeeder.php
+++ b/kelasi/database/seeders/AcademicYearSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\AcademicYear;
+
+class AcademicYearSeeder extends Seeder
+{
+    public function run(): void
+    {
+        AcademicYear::create([
+            'name' => '2024-2025',
+            'start_date' => '2024-09-01',
+            'end_date' => '2025-06-30',
+            'is_active' => true,
+        ]);
+    }
+}

--- a/kelasi/database/seeders/ClassSeeder.php
+++ b/kelasi/database/seeders/ClassSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\SchoolClass;
+use App\Models\School;
+use App\Models\AcademicYear;
+
+class ClassSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $school = School::first();
+        $year = AcademicYear::first();
+
+        SchoolClass::create([
+            'school_id' => $school->id,
+            'academic_year_id' => $year->id,
+            'name' => 'Class A',
+            'level' => '1',
+        ]);
+    }
+}

--- a/kelasi/database/seeders/DatabaseSeeder.php
+++ b/kelasi/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,19 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call([
+            SchoolSeeder::class,
+            AcademicYearSeeder::class,
+            ClassSeeder::class,
+            ParentSeeder::class,
+            StudentSeeder::class,
+            TeacherSeeder::class,
+            SubjectSeeder::class,
+            FeeSeeder::class,
+            PaymentSeeder::class,
+            GradeSeeder::class,
+            RoleSeeder::class,
+        ]);
     }
 }

--- a/kelasi/database/seeders/FeeSeeder.php
+++ b/kelasi/database/seeders/FeeSeeder.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Fee;
+use App\Models\School;
+
+class FeeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $school = School::first();
+
+        Fee::create([
+            'school_id' => $school->id,
+            'name' => 'Tuition',
+            'amount' => 500.00,
+        ]);
+    }
+}

--- a/kelasi/database/seeders/GradeSeeder.php
+++ b/kelasi/database/seeders/GradeSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Grade;
+use App\Models\Student;
+use App\Models\Subject;
+use App\Models\Teacher;
+use App\Models\AcademicYear;
+
+class GradeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $student = Student::first();
+        $subject = Subject::first();
+        $teacher = Teacher::first();
+        $year = AcademicYear::first();
+
+        Grade::create([
+            'student_id' => $student->id,
+            'subject_id' => $subject->id,
+            'teacher_id' => $teacher->id,
+            'academic_year_id' => $year->id,
+            'value' => 15.5,
+        ]);
+    }
+}

--- a/kelasi/database/seeders/ParentSeeder.php
+++ b/kelasi/database/seeders/ParentSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ParentModel;
+
+class ParentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        ParentModel::create([
+            'name' => 'John Doe',
+            'email' => 'parent@example.com',
+            'phone' => '0202020202',
+            'address' => 'Parent Street 1',
+        ]);
+    }
+}

--- a/kelasi/database/seeders/PaymentSeeder.php
+++ b/kelasi/database/seeders/PaymentSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Payment;
+use App\Models\Student;
+use App\Models\Fee;
+
+class PaymentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $student = Student::first();
+        $fee = Fee::first();
+
+        Payment::create([
+            'student_id' => $student->id,
+            'fee_id' => $fee->id,
+            'amount' => 250.00,
+            'payment_date' => '2024-10-01',
+        ]);
+    }
+}

--- a/kelasi/database/seeders/RoleSeeder.php
+++ b/kelasi/database/seeders/RoleSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Role;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $roles = ['administrateur', 'direction', 'enseignant', 'comptable', 'parent'];
+
+        foreach ($roles as $role) {
+            Role::create(['name' => $role]);
+        }
+    }
+}

--- a/kelasi/database/seeders/SchoolSeeder.php
+++ b/kelasi/database/seeders/SchoolSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\School;
+
+class SchoolSeeder extends Seeder
+{
+    public function run(): void
+    {
+        School::create([
+            'name' => 'Main School',
+            'address' => '123 Avenue',
+            'phone' => '0101010101',
+            'email' => 'info@mainschool.test',
+        ]);
+    }
+}

--- a/kelasi/database/seeders/StudentSeeder.php
+++ b/kelasi/database/seeders/StudentSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Student;
+use App\Models\School;
+use App\Models\SchoolClass;
+use App\Models\ParentModel;
+
+class StudentSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $school = School::first();
+        $class = SchoolClass::first();
+        $parent = ParentModel::first();
+
+        Student::create([
+            'school_id' => $school->id,
+            'class_id' => $class->id,
+            'parent_id' => $parent->id,
+            'first_name' => 'Alice',
+            'last_name' => 'Smith',
+            'birth_date' => '2010-05-10',
+            'gender' => 'F',
+        ]);
+    }
+}

--- a/kelasi/database/seeders/SubjectSeeder.php
+++ b/kelasi/database/seeders/SubjectSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Subject;
+
+class SubjectSeeder extends Seeder
+{
+    public function run(): void
+    {
+        Subject::create([
+            'name' => 'Mathematics',
+            'code' => 'MATH',
+        ]);
+    }
+}

--- a/kelasi/database/seeders/TeacherSeeder.php
+++ b/kelasi/database/seeders/TeacherSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Teacher;
+use App\Models\School;
+
+class TeacherSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $school = School::first();
+
+        Teacher::create([
+            'school_id' => $school->id,
+            'first_name' => 'Mark',
+            'last_name' => 'Brown',
+            'email' => 'teacher@example.com',
+            'phone' => '0303030303',
+            'hire_date' => '2023-09-01',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- create migrations for core tables (schools, academic years, classes, parents, students, teachers, subjects, fees, payments, grades, roles)
- add Eloquent models with relationships
- extend `User` model with roles relation
- provide seeders to bootstrap demo data and update `DatabaseSeeder`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a2d3feec8320a364008524054591