### PR TITLE
Set login page as home

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,11 +3,12 @@
 use App\Livewire\Settings\Appearance;
 use App\Livewire\Settings\Password;
 use App\Livewire\Settings\Profile;
+use App\Livewire\Auth\Login;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-})->name('home');
+Route::get('/', Login::class)
+    ->middleware('guest')
+    ->name('home');
 
 Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])


### PR DESCRIPTION
## Summary
- serve the authentication screen as the home page

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af3ae6c348320b22ea8fb653e9fa7