### PR TITLE
Remove Vite asset loading

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -10,7 +10,6 @@
 <link rel="preconnect" href="https://fonts.bunny.net">
 <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
-@vite(['resources/css/app.css', 'resources/js/app.js'])
 <link rel="stylesheet" href="{{ asset('css/style.css') }}">
 <script src="{{ asset('js/app.js') }}" defer></script>
 @fluxAppearance


### PR DESCRIPTION
## Summary
- strip Vite asset loading from the head partial and only use asset() links

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68511c4c45848320aee3b3c93202a9fc